### PR TITLE
[BugFix]: Provide backward compatibility for missing 'instances'

### DIFF
--- a/include/autonomy_core/autonomy.h
+++ b/include/autonomy_core/autonomy.h
@@ -254,6 +254,13 @@ private:
   void getParameter(T& param, const std::string& name, const std::string& msg = "");
 
   /**
+   * @brief Method to get a parameter from the parameter server and handle UI, logging and default value if parameter is
+   * not found
+   */
+  template <typename T>
+  void getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg = "");
+
+  /**
    * @brief Method to get the missions from the parameter server and handle UI, logging and failure
    */
   void getMissions();

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -138,6 +138,18 @@ void Autonomy::getParameter(T& param, const std::string& name, const std::string
   }
 }
 
+template <typename T>
+void Autonomy::getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg)
+{
+  if (!nh_.getParam(name, param))
+  {
+    param = value;
+    logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE), formatParamNotFound(name, msg));
+    logger_.logInfo(state_->getStringFromState(),
+                    "[" + name + "] parameter not defined, using " + std::to_string(value) + ".");
+  }
+}
+
 void Autonomy::getMissions()
 {
   // Define auxilliary variables foreach paramter: XmlRpc::XmlRpcValue
@@ -211,7 +223,8 @@ void Autonomy::getMissions()
       }
 
       // get the mission repetitions
-      getParameter(instances, "missions/mission_" + std::to_string(i) + "/instances");
+      getParameterDefault(instances, "missions/mission_" + std::to_string(i) + "/instances", 1,
+                          "Defaulting to single instance.");
 
       // Check value of instances of the mission
       // If it is less then -1 or 0 trigger a failure


### PR DESCRIPTION
### Summary
Provides compatibility for configs without the 'instances' parameter, assuming only 1 instance to be run.

### Changelog
#### Fixes
- Fixes https://github.com/aau-cns/autonomy_engine/issues/7.