### PR TITLE
[BugFix] Issue with autonomy transitioning in termination state

### DIFF
--- a/include/autonomy_core/autonomy.h
+++ b/include/autonomy_core/autonomy.h
@@ -254,6 +254,13 @@ private:
   void getParameter(T& param, const std::string& name, const std::string& msg = "");
 
   /**
+   * @brief Method to get a parameter from the parameter server and handle UI, logging and default value if parameter is
+   * not found
+   */
+  template <typename T>
+  void getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg = "");
+
+  /**
    * @brief Method to get the missions from the parameter server and handle UI, logging and failure
    */
   void getMissions();

--- a/include/autonomy_core/autonomy.h
+++ b/include/autonomy_core/autonomy.h
@@ -358,6 +358,23 @@ private:
   std::atomic<bool> register_aux_ = false;
   std::atomic<bool> aux_registered_ = false;
 
+  /// Allowed state transitions
+  const std::unordered_map<std::string, std::vector<std::string>> allowed_state_transitions_ = {
+    { "undefined", { "initialization", "termination" } },
+    { "initialization", { "nominal", "failure", "termination" } },
+    { "nominal", { "preflight", "failure", "termination" } },
+    { "preflight", { "start_mission", "failure", "termination" } },
+    { "start_mission", { "perform_mission", "hold", "land", "failure", "termination" } },
+    { "perform_mission", { "hold", "land", "failure", "termination" } },
+    { "mission_iterator", { "preflight", "start_mission", "hold", "land", "failure", "termination" } },
+    { "end_mission", { "mission_iterator", "hold", "land", "failure", "termination" } },
+    { "land", { "end_mission", "hold", "failure", "termination" } },
+    { "hold",
+      { "start_mission", "perform_mission", "mission_iterator", "end_mission", "land", "failure", "termination" } },
+    { "failure", { "termination" } },
+    { "termination", {} }
+  };
+
 };  // class Autonomy
 
 }  // namespace autonomy

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1437,7 +1437,7 @@ bool Autonomy::estimatorCheck()
       logger_.logServiceResponse(state_->getStringFromState(), opts_->estimator_supervisor_service_name,
                                  "State estimator checks succeeded");
       logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE),
-                    formatMsg("State estimator Correctly initilized", 2));
+                    formatMsg("State estimator correctly initialized", 2));
     }
     else
     {
@@ -1638,6 +1638,10 @@ void Autonomy::stateTransition(std::string str)
   // Execute predefined behavior on Exiting old state
   state_->onExit(*this);
 
+  // Check if we are currently in failure or termination state -> no state transition allowed
+  bool failure =
+      state_->getStringFromState().compare("failure") == 0 || state_->getStringFromState().compare("termination") == 0;
+
   // Execute state transition
   logger_.logStateChange(state_->getStringFromState(), str);
   if (str.compare("undefined") == 0)
@@ -1648,50 +1652,50 @@ void Autonomy::stateTransition(std::string str)
   {
     state_ = &Initialization::Instance();
   }
-  else if ((str.compare("nominal") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("nominal") == 0) && !failure)
   {
     state_ = &Nominal::Instance();
   }
-  else if ((str.compare("failure") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("failure") == 0) && !failure)
   {
     state_ = &Failure::Instance();
   }
-  else if ((str.compare("preflight") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("preflight") == 0) && !failure)
   {
     state_ = &Preflight::Instance();
   }
-  else if ((str.compare("start_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("start_mission") == 0) && !failure)
   {
     state_ = &StartMission::Instance();
   }
-  else if ((str.compare("perform_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("perform_mission") == 0) && !failure)
   {
     state_ = &PerformMission::Instance();
   }
-  else if ((str.compare("mission_iterator") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("mission_iterator") == 0) && !failure)
   {
     state_ = &MissionIterator::Instance();
   }
-  else if ((str.compare("end_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("end_mission") == 0) && !failure)
   {
     state_ = &EndMission::Instance();
   }
-  else if ((str.compare("land") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("land") == 0) && !failure)
   {
     state_ = &Land::Instance();
   }
-  else if ((str.compare("hold") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("hold") == 0) && !failure)
   {
     state_ = &Hold::Instance();
   }
-  else if (str.compare("termination") == 0)
+  else if (str.compare("termination") == 0 && state_->getStringFromState().compare("termination") != 0)
   {
     state_ = &Termination::Instance();
   }
   else
   {
     logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, RED_ESCAPE),
-                  formatMsg("Wrong state transition required", 2));
+                  formatMsg("Not allowed to transition to '" + str + "' state", 2));
     state_ = &Failure::Instance();
   }
 

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1638,57 +1638,60 @@ void Autonomy::stateTransition(std::string str)
   // Execute predefined behavior on Exiting old state
   state_->onExit(*this);
 
-  // Check if we are currently in failure or termination state -> no state transition allowed
-  bool failure =
-      state_->getStringFromState().compare("failure") == 0 || state_->getStringFromState().compare("termination") == 0;
+  auto transitionAllowed = [&]() {
+    const auto& allowed = allowed_state_transitions_.at(state_->getStringFromState());
+    return std::find(allowed.begin(), allowed.end(), str) != allowed.end() ? true : false;
+  };
+
+  // Log
+  logger_.logStateChange(state_->getStringFromState(), str);
 
   // Execute state transition
-  logger_.logStateChange(state_->getStringFromState(), str);
-  if (str.compare("undefined") == 0)
+  if (str.compare("undefined") == 0 && transitionAllowed())
   {
     state_ = &Undefined::Instance();
   }
-  else if (str.compare("initialization") == 0)
+  else if (str.compare("initialization") == 0 && transitionAllowed())
   {
     state_ = &Initialization::Instance();
   }
-  else if ((str.compare("nominal") == 0) && !failure)
+  else if ((str.compare("nominal") == 0) && transitionAllowed())
   {
     state_ = &Nominal::Instance();
   }
-  else if ((str.compare("failure") == 0) && !failure)
+  else if ((str.compare("failure") == 0) && transitionAllowed())
   {
     state_ = &Failure::Instance();
   }
-  else if ((str.compare("preflight") == 0) && !failure)
+  else if ((str.compare("preflight") == 0) && transitionAllowed())
   {
     state_ = &Preflight::Instance();
   }
-  else if ((str.compare("start_mission") == 0) && !failure)
+  else if ((str.compare("start_mission") == 0) && transitionAllowed())
   {
     state_ = &StartMission::Instance();
   }
-  else if ((str.compare("perform_mission") == 0) && !failure)
+  else if ((str.compare("perform_mission") == 0) && transitionAllowed())
   {
     state_ = &PerformMission::Instance();
   }
-  else if ((str.compare("mission_iterator") == 0) && !failure)
+  else if ((str.compare("mission_iterator") == 0) && transitionAllowed())
   {
     state_ = &MissionIterator::Instance();
   }
-  else if ((str.compare("end_mission") == 0) && !failure)
+  else if ((str.compare("end_mission") == 0) && transitionAllowed())
   {
     state_ = &EndMission::Instance();
   }
-  else if ((str.compare("land") == 0) && !failure)
+  else if ((str.compare("land") == 0) && transitionAllowed())
   {
     state_ = &Land::Instance();
   }
-  else if ((str.compare("hold") == 0) && !failure)
+  else if ((str.compare("hold") == 0) && transitionAllowed())
   {
     state_ = &Hold::Instance();
   }
-  else if (str.compare("termination") == 0 && state_->getStringFromState().compare("termination") != 0)
+  else if (str.compare("termination") == 0 && transitionAllowed())
   {
     state_ = &Termination::Instance();
   }

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -138,6 +138,18 @@ void Autonomy::getParameter(T& param, const std::string& name, const std::string
   }
 }
 
+template <typename T>
+void Autonomy::getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg)
+{
+  if (!nh_.getParam(name, param))
+  {
+    param = value;
+    logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE), formatParamNotFound(name, msg));
+    logger_.logInfo(state_->getStringFromState(),
+                    "[" + name + "] parameter not defined, using " + std::to_string(value) + ".");
+  }
+}
+
 void Autonomy::getMissions()
 {
   // Define auxilliary variables foreach paramter: XmlRpc::XmlRpcValue
@@ -211,7 +223,8 @@ void Autonomy::getMissions()
       }
 
       // get the mission repetitions
-      getParameter(instances, "missions/mission_" + std::to_string(i) + "/instances");
+      getParameterDefault(instances, "missions/mission_" + std::to_string(i) + "/instances", 1,
+                          "Defaulting to single instance.");
 
       // Check value of instances of the mission
       // If it is less then -1 or 0 trigger a failure


### PR DESCRIPTION
### Changelog
#### Fixes
- Prevent autonomy transitioning out of `termination` state.
- Checks if we are transitioning from `termination` state to `termination` state to prevent recursive switching when being terminated.
- Prevents recursive calling and unnecassary output on terminal