### PR TITLE
[BugFix] Various minor logic fixes and input handling

### DIFF
--- a/config/trajectories/template_dir/template_trajectory.csv
+++ b/config/trajectories/template_dir/template_trajectory.csv
@@ -1,2 +1,3 @@
 x,y,z,yaw,holdtime
 0,0,1.0,0,10
+

--- a/include/autonomy_core/autonomy.h
+++ b/include/autonomy_core/autonomy.h
@@ -254,6 +254,13 @@ private:
   void getParameter(T& param, const std::string& name, const std::string& msg = "");
 
   /**
+   * @brief Method to get a parameter from the parameter server and handle UI, logging and default value if parameter is
+   * not found
+   */
+  template <typename T>
+  void getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg = "");
+
+  /**
    * @brief Method to get the missions from the parameter server and handle UI, logging and failure
    */
   void getMissions();

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1330,12 +1330,8 @@ void Autonomy::missionSelection()
   {
     logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, RED_ESCAPE), "\n >>> Wrong mission ID chosen\n\n");
 
-    // HACK(scm): CTRL+C creates mission_id_ = -1, so only continue if mission_id_ is not -1
-    if (mission_id_ != -1)
-    {
-      // Call recursively mission selection
-      missionSelection();
-    }
+    // Call recursively mission selection
+    missionSelection();
   }
   else
   {

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1437,7 +1437,7 @@ bool Autonomy::estimatorCheck()
       logger_.logServiceResponse(state_->getStringFromState(), opts_->estimator_supervisor_service_name,
                                  "State estimator checks succeeded");
       logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE),
-                    formatMsg("State estimator Correctly initilized", 2));
+                    formatMsg("State estimator correctly initialized", 2));
     }
     else
     {
@@ -1638,6 +1638,10 @@ void Autonomy::stateTransition(std::string str)
   // Execute predefined behavior on Exiting old state
   state_->onExit(*this);
 
+  // Check if we are currently in failure or termination state -> no state transition allowed
+  bool failure =
+      state_->getStringFromState().compare("failure") == 0 || state_->getStringFromState().compare("termination") == 0;
+
   // Execute state transition
   logger_.logStateChange(state_->getStringFromState(), str);
   if (str.compare("undefined") == 0)
@@ -1648,50 +1652,50 @@ void Autonomy::stateTransition(std::string str)
   {
     state_ = &Initialization::Instance();
   }
-  else if ((str.compare("nominal") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("nominal") == 0) && !failure)
   {
     state_ = &Nominal::Instance();
   }
-  else if ((str.compare("failure") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("failure") == 0) && !failure)
   {
     state_ = &Failure::Instance();
   }
-  else if ((str.compare("preflight") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("preflight") == 0) && !failure)
   {
     state_ = &Preflight::Instance();
   }
-  else if ((str.compare("start_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("start_mission") == 0) && !failure)
   {
     state_ = &StartMission::Instance();
   }
-  else if ((str.compare("perform_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("perform_mission") == 0) && !failure)
   {
     state_ = &PerformMission::Instance();
   }
-  else if ((str.compare("mission_iterator") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("mission_iterator") == 0) && !failure)
   {
     state_ = &MissionIterator::Instance();
   }
-  else if ((str.compare("end_mission") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("end_mission") == 0) && !failure)
   {
     state_ = &EndMission::Instance();
   }
-  else if ((str.compare("land") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("land") == 0) && !failure)
   {
     state_ = &Land::Instance();
   }
-  else if ((str.compare("hold") == 0) && (state_->getStringFromState().compare("failure") != 0))
+  else if ((str.compare("hold") == 0) && !failure)
   {
     state_ = &Hold::Instance();
   }
-  else if (str.compare("termination") == 0)
+  else if (str.compare("termination") == 0 && state_->getStringFromState().compare("termination") != 0)
   {
     state_ = &Termination::Instance();
   }
   else
   {
     logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, RED_ESCAPE),
-                  formatMsg("Wrong state transition required", 2));
+                  formatMsg("Not allowed to transition to '" + str + "' state", 2));
     state_ = &Failure::Instance();
   }
 

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1337,8 +1337,12 @@ void Autonomy::missionSelection()
   {
     logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, RED_ESCAPE), "\n >>> Wrong mission ID chosen\n\n");
 
-    // Call recursively mission selection
-    missionSelection();
+    // HACK(scm): CTRL+C creates mission_id_ = -1, so only continue if mission_id_ is not -1
+    if (mission_id_ != -1)
+    {
+      // Call recursively mission selection
+      missionSelection();
+    }
   }
   else
   {

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -695,7 +695,14 @@ void Autonomy::watchdogStatusCallback(const watchdog_msgs::StatusChangesArraySta
           // perform any state transition
           if (missions_.at(mission_id_).getNextState(status.entity).compare("failure") != 0)
           {
-            if (in_flight_)
+            // check if next state is continue, then we only log the failure and continue
+            if (missions_.at(mission_id_).getNextState(status.entity).compare("continue") == 0)
+            {
+              logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE),
+                            formatMsg("Failure logged,; Action: continue -> continuing..."));
+            }
+            // otherwise check if we are flying to execute state transition
+            else if (in_flight_)
             {
               stateTransition(missions_.at(mission_id_).getNextState(status.entity));
             }
@@ -781,7 +788,7 @@ void Autonomy::watchdogStatusCallback(const watchdog_msgs::StatusChangesArraySta
                     formatMsg("[watchdogStatusCallback] Wrong message received from watchdog"));
     }
   }
-}
+}  // namespace autonomy
 
 void Autonomy::watchdogActionRequest(SensorStatus& status, const watchdog_msgs::Status& status_msg)
 {

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -1054,11 +1054,30 @@ void Autonomy::missionSequencerResponceCallback(const mission_sequencer::Mission
       // Check if landing detection is active, if not transit to END_MISSION
       if (!opts_->activate_landing_detection && land_expected_)
       {
+        logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Landing completed"));
+
         // reset land_expected_ flag
         land_expected_ = false;
 
         // Call state transition to END MISSION
         stateTransition("end_mission");
+      }
+    }
+    else if (!msg->response && msg->completed && msg->request.request == mission_sequencer::MissionRequest::DISARM)
+    {
+      logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Disarming completed"));
+
+      // Reset armed_ flag
+      armed_ = false;
+
+      // Stop flight timer
+      // If doing multiple touchdown i do so when the filepaths counter is equal to the number of filepaths -1,
+      // and when the istances counter is equal to the number of instances -1 (since both counters start at 0)
+      if (!multiple_touchdowns_ ||
+          (filepaths_cnt_ == (missions_.at(mission_id_).getFilepaths().size() - 1) &&
+           instances_cnt_ == (static_cast<size_t>(missions_.at(mission_id_).getInstances()) - 1)))
+      {
+        flight_timer_->stopTimer();
       }
     }
     else

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -138,6 +138,18 @@ void Autonomy::getParameter(T& param, const std::string& name, const std::string
   }
 }
 
+template <typename T>
+void Autonomy::getParameterDefault(T& param, const std::string& name, const T& value, const std::string& msg)
+{
+  if (!nh_.getParam(name, param))
+  {
+    param = value;
+    logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE), formatParamNotFound(name, msg));
+    logger_.logInfo(state_->getStringFromState(),
+                    "[" + name + "] parameter not defined, using " + std::to_string(value) + ".");
+  }
+}
+
 void Autonomy::getMissions()
 {
   // Define auxilliary variables foreach paramter: XmlRpc::XmlRpcValue
@@ -211,7 +223,8 @@ void Autonomy::getMissions()
       }
 
       // get the mission repetitions
-      getParameter(instances, "missions/mission_" + std::to_string(i) + "/instances");
+      getParameterDefault(instances, "missions/mission_" + std::to_string(i) + "/instances", 1,
+                          "Defaulting to single instance.");
 
       // Check value of instances of the mission
       // If it is less then -1 or 0 trigger a failure

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -49,7 +49,7 @@ Autonomy::Autonomy(ros::NodeHandle& nh) : logger_(nh), nh_(nh)
   ss << "autonomy-" << std::setw(4) << std::setfill('0') << (1900 + ltm->tm_year) << "-" << std::setw(2)
      << std::setfill('0') << int(1 + ltm->tm_mon) << "-" << std::setw(2) << std::setfill('0') << int(ltm->tm_mday)
      << "-" << std::setw(2) << std::setfill('0') << int(ltm->tm_hour) << "-" << std::setw(2) << std::setfill('0')
-     << int(ltm->tm_min) << "-" << int(ltm->tm_sec) << ".log";
+     << int(ltm->tm_min) << "-" << std::setw(2) << std::setfill('0') << int(ltm->tm_sec) << ".log";
   logger_.initFileLogger(std::string(opts_->logger_filepath) + ss.str());
 
   // Init message

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -941,19 +941,6 @@ void Autonomy::missionSequencerResponceCallback(const mission_sequencer::Mission
 
           case mission_sequencer::MissionRequest::DISARM:
 
-            // Reset armed_ flag
-            armed_ = false;
-
-            // Stop flight timer
-            // If doing multiple touchdown i do so when the filepaths counter is equal to the number of filepaths -1,
-            // and when the istances counter is equal to the number of instances -1 (since both counters start at 0)
-            if (!multiple_touchdowns_ ||
-                (filepaths_cnt_ == (missions_.at(mission_id_).getFilepaths().size() - 1) &&
-                 instances_cnt_ == (static_cast<size_t>(missions_.at(mission_id_).getInstances()) - 1)))
-            {
-              flight_timer_->stopTimer();
-            }
-
             break;
         }
       }
@@ -967,8 +954,6 @@ void Autonomy::missionSequencerResponceCallback(const mission_sequencer::Mission
                                 2));
         stateTransition("failure");
       }
-
-      // Check if mission has been compoleted (last waypoint reached)
     }
     else if (!msg->response && msg->completed && msg->request.request == mission_sequencer::MissionRequest::UNDEF)
     {
@@ -1063,7 +1048,8 @@ void Autonomy::missionSequencerResponceCallback(const mission_sequencer::Mission
       {
         logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Landing completed"));
 
-        // reset land_expected_ flag
+        // Reset in_flight_ and land_expected_ flag
+        in_flight_ = false;
         land_expected_ = false;
 
         // Call state transition to END MISSION
@@ -1074,11 +1060,11 @@ void Autonomy::missionSequencerResponceCallback(const mission_sequencer::Mission
     {
       logger_.logUI(state_->getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Disarming completed"));
 
-      // Reset armed_ flag
+      // Reset armed_ and in_flight_ flag
       armed_ = false;
 
-      // Stop flight timer
-      // If doing multiple touchdown i do so when the filepaths counter is equal to the number of filepaths -1,
+      // Stop flight timer.
+      // If doing multiple touchdown stop the timer when the filepaths counter is equal to the number of filepaths -1,
       // and when the istances counter is equal to the number of instances -1 (since both counters start at 0)
       if (!multiple_touchdowns_ ||
           (filepaths_cnt_ == (missions_.at(mission_id_).getFilepaths().size() - 1) &&

--- a/src/autonomy_core/autonomy.cpp
+++ b/src/autonomy_core/autonomy.cpp
@@ -788,7 +788,7 @@ void Autonomy::watchdogStatusCallback(const watchdog_msgs::StatusChangesArraySta
                     formatMsg("[watchdogStatusCallback] Wrong message received from watchdog"));
     }
   }
-}  // namespace autonomy
+}
 
 void Autonomy::watchdogActionRequest(SensorStatus& status, const watchdog_msgs::Status& status_msg)
 {

--- a/src/state_machine/states/end_mission.cpp
+++ b/src/state_machine/states/end_mission.cpp
@@ -25,89 +25,41 @@ State& EndMission::Instance()
 
 void EndMission::onEntry(Autonomy& autonomy)
 {
+  // This state is reached, if the landing has been confirmed by mission sequencer or landing detector
+
   // print info
   autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatStateEntry("MISSION (ENDING)"));
-
-  // This state is reached, if the landing has been confirmed by mission sequencer or landing detector
-  // thus disarm the platform
 
   // Print info
   autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Disarm...", 2));
 
-  // Disarm request in case of no landing detection
-  if (autonomy.armed_)
+  if (autonomy.opts_->activate_landing_detection)
   {
-    if (!autonomy.opts_->activate_landing_detection)
+    // Disarm request
+    if (autonomy.armed_)
+    {
       autonomy.missionSequencerRequest(mission_sequencer::MissionRequest::DISARM);
+    }
+    else
+    {
+      autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE),
+                             formatMsg("The platform is already disarmed, skipped DISARM request", 2));
+    }
   }
-  else
-  {
-    autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE),
-                           formatMsg("The platform is already disarmed, skipped DISARM request", 2));
-  }
-
-  int disarm_cnt = 0;
+  // else
+  // {
+  //   // If landing detection is not active assume the disarm will happen automatically otherwise send a disarm request
+  //   // and wait for disarming. Assuming the disarm will happen automatically rather than sending an explicit request is
+  //   // safer since we are not sure the platform is on the ground. For the sake of completeness, a commented disarm
+  //   // request is kept here
+  //   autonomy.missionSequencerRequest(mission_sequencer::MissionRequest::DISARM);
+  // }
 
   // Wait until disarm request got accepted
   while (autonomy.armed_)
   {
     autonomy.polling(10);
-    if (disarm_cnt++ == 10)
-    {
-      autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE),
-                             formatMsg("Disarm request not successfull, retrying...", 2));
-      autonomy.missionSequencerRequest(mission_sequencer::MissionRequest::DISARM);
-    }
   }
-
-  // redundant reset for amed and in flight flag
-  autonomy.armed_ = false;
-  autonomy.in_flight_ = false;
-
-  // OLD CODE
-  // // Assume the disarm will happen automatically if we do not activate the landing detection thus set the armed_ flag
-  // // Otherwise send a disarm request and wait for disarming
-  // if (!autonomy.opts_->activate_landing_detection)
-  // {
-  //   // Reset armed_ and in_flight_ flag
-  //   autonomy.armed_ = false;
-  //   autonomy.in_flight_ = false;
-
-  //   // Stop flight timer
-  //   // If doing multiple touchdown i do so when the filepaths counter is equal to the number of filepaths -1, and
-  //   when
-  //   // the istances counter is equal to the number of instances -1 (since both counters start at 0)
-  //   if (!autonomy.multiple_touchdowns_ ||
-  //       (autonomy.filepaths_cnt_ == (autonomy.missions_.at(autonomy.mission_id_).getFilepaths().size() - 1) &&
-  //        autonomy.instances_cnt_ ==
-  //            (static_cast<size_t>(autonomy.missions_.at(autonomy.mission_id_).getInstances()) - 1)))
-  //   {
-  //     autonomy.flight_timer_->stopTimer();
-  //   }
-  // }
-  // else
-  // {
-  //   // Print info
-  //   autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, GREEN_ESCAPE), formatMsg("Disarm...", 2));
-
-  //   // Disarm request
-  //   if (autonomy.armed_)
-  //   {
-  //     autonomy.missionSequencerRequest(mission_sequencer::MissionRequest::DISARM);
-  //   }
-  //   else
-  //   {
-  //     autonomy.logger_.logUI(getStringFromState(), ESCAPE(BOLD_ESCAPE, YELLOW_ESCAPE),
-  //                            formatMsg("The platform is already disarmed, skipped DISARM request", 2));
-  //   }
-
-  //   // Wait until disarm request got accepted
-  //   while (autonomy.armed_)
-  //   {
-  //     autonomy.polling(10);
-  //   }
-  // }
-  // OLD CODE END
 
   // Check if we are here because mission got succesfully completed (last waypoint reached)
   // or if we safely land

--- a/src/waypoints_parser/waypoints_parser.cpp
+++ b/src/waypoints_parser/waypoints_parser.cpp
@@ -161,7 +161,6 @@ bool WaypointsParser::fileSanityCheck()
       parseLine(line, tmp);
       if (tmp.size() != 0 && tmp.size() != indices.size())
       {
-        // only care for wrongly formatted lines, not empty lines
         return false;
       }
       for (const auto& it : tmp)

--- a/src/waypoints_parser/waypoints_parser.cpp
+++ b/src/waypoints_parser/waypoints_parser.cpp
@@ -159,8 +159,9 @@ bool WaypointsParser::fileSanityCheck()
     {
       std::vector<std::string> tmp;
       parseLine(line, tmp);
-      if (tmp.size() != indices.size())
+      if (tmp.size() != 0 && tmp.size() != indices.size())
       {
+        // only care for wrongly formatted lines, not empty lines
         return false;
       }
       for (const auto& it : tmp)


### PR DESCRIPTION
### Summary

Various bugfixes

### Changelog
#### Fixes
- Race-condition lead to autonomy not registering "arming successful" callback by mission sequencer.
- CTRL+C does not trigger consecutive terminations --> only once now (no polluted terminal)
- CSV for trajectories can now have multiple empty lines at the end.
- Seconds of the logfile was missing a leading "0" if below 10.
- "Continue" in entities does not create failure anymore.